### PR TITLE
feat: add ingestion configuration and processing notebook for data loading

### DIFF
--- a/config/ingestion.json
+++ b/config/ingestion.json
@@ -1,0 +1,26 @@
+[
+    {
+        "table": "clientes",
+        "path": "../data/clientes.csv"
+    },
+    {
+        "table": "devolucoes",
+        "path": "../data/devolucoes.csv"
+    },
+    {
+        "table": "itens_devolucao",
+        "path": "../data/itens_devolucao.csv"
+    },
+    {
+        "table": "itens_venda",
+        "path": "../data/itens_venda.csv"
+    },
+    {
+        "table": "produtos",
+        "path": "../data/produtos.csv"
+    },
+    {
+        "table": "vendas",
+        "path": "../data/vendas.csv"
+    }
+]

--- a/notebooks/ingestion.ipynb
+++ b/notebooks/ingestion.ipynb
@@ -1,0 +1,259 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55ca351c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "from sqlalchemy import create_engine\n",
+    "from urllib.parse import quote_plus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75edcd37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"../config/ingestion.json\", \"r\") as open_json:\n",
+    "    ingestions = json.load(open_json)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c53ab50c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Leitura do arquivo\n",
+    "dfs = {}\n",
+    "\n",
+    "for item in ingestions:\n",
+    "    table = item[\"table\"]\n",
+    "    path = item[\"path\"]\n",
+    "\n",
+    "    try:\n",
+    "        df = pd.read_csv(path, encoding=\"utf-8\", sep=\";\")\n",
+    "        dfs[table] = df\n",
+    "        print(f\"Tabela {table} lida.\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"Erro ao ler a tabela {table}.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "a74d1132",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dfs[\"vendas\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "18bc6a9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\i4nge\\AppData\\Local\\Temp\\ipykernel_24656\\4150470770.py:3: UserWarning: Parsing dates in %d/%m/%Y format when dayfirst=False (the default) was specified. Pass `dayfirst=True` or specify a format to silence this warning.\n",
+      "  df[\"data_venda\"] = pd.to_datetime(df[\"data_venda\"])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tratamento de data\n",
+    "\n",
+    "df[\"data_venda\"] = pd.to_datetime(df[\"data_venda\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "e02d68ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id_venda</th>\n",
+       "      <th>id_cliente</th>\n",
+       "      <th>data_venda</th>\n",
+       "      <th>canal_venda</th>\n",
+       "      <th>status_venda</th>\n",
+       "      <th>total_venda</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>a8cdf44d-7b74-4440-97db-4c2f1e158e2f</td>\n",
+       "      <td>cb35097a-e5dd-48f1-88a7-38ab0df83e12</td>\n",
+       "      <td>2025-01-26</td>\n",
+       "      <td>app móvel</td>\n",
+       "      <td>concluída</td>\n",
+       "      <td>685.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>e869707c-bdcb-4ffc-8dfb-a4e996cbdafb</td>\n",
+       "      <td>b8db0672-f42d-47cc-80d4-af5974273ca3</td>\n",
+       "      <td>2025-04-22</td>\n",
+       "      <td>app móvel</td>\n",
+       "      <td>concluída</td>\n",
+       "      <td>329.97</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>41ff81d1-689d-4205-8b31-f4d8e073c1d0</td>\n",
+       "      <td>177d6e7e-07d9-44ce-b8c8-8faea2178f84</td>\n",
+       "      <td>2025-02-06</td>\n",
+       "      <td>site</td>\n",
+       "      <td>concluída</td>\n",
+       "      <td>179.98</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>6d130705-279f-41ab-9b49-09b65cbdb682</td>\n",
+       "      <td>b12b6680-7f07-4cb9-afd3-40c0f945f2fd</td>\n",
+       "      <td>2025-05-07</td>\n",
+       "      <td>app móvel</td>\n",
+       "      <td>concluída</td>\n",
+       "      <td>2399.95</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>ae3c2ce6-fde6-449b-868b-22af9ca4364d</td>\n",
+       "      <td>56666f9f-53ac-4ab9-b467-2cd9362f5e5c</td>\n",
+       "      <td>2025-03-19</td>\n",
+       "      <td>marketplace</td>\n",
+       "      <td>cancelada</td>\n",
+       "      <td>90.00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                               id_venda                            id_cliente  \\\n",
+       "0  a8cdf44d-7b74-4440-97db-4c2f1e158e2f  cb35097a-e5dd-48f1-88a7-38ab0df83e12   \n",
+       "1  e869707c-bdcb-4ffc-8dfb-a4e996cbdafb  b8db0672-f42d-47cc-80d4-af5974273ca3   \n",
+       "2  41ff81d1-689d-4205-8b31-f4d8e073c1d0  177d6e7e-07d9-44ce-b8c8-8faea2178f84   \n",
+       "3  6d130705-279f-41ab-9b49-09b65cbdb682  b12b6680-7f07-4cb9-afd3-40c0f945f2fd   \n",
+       "4  ae3c2ce6-fde6-449b-868b-22af9ca4364d  56666f9f-53ac-4ab9-b467-2cd9362f5e5c   \n",
+       "\n",
+       "  data_venda  canal_venda status_venda  total_venda  \n",
+       "0 2025-01-26    app móvel    concluída       685.00  \n",
+       "1 2025-04-22    app móvel    concluída       329.97  \n",
+       "2 2025-02-06         site    concluída       179.98  \n",
+       "3 2025-05-07    app móvel    concluída      2399.95  \n",
+       "4 2025-03-19  marketplace    cancelada        90.00  "
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c0ea443",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Senha do MySQL\n",
+    "load_dotenv()\n",
+    "password = quote_plus(os.getenv(\"DB_PASSWORD\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d69b5435",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Criando a engine\n",
+    "engine = create_engine(f\"mysql+pymysql://root:{password}@localhost/cosmolume\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "78aef232",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3169"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Carregar dados no banco\n",
+    "df.to_sql(\"vendas\", con=engine, if_exists=\"append\", index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "astronomy-ecommerce",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request introduces a new data ingestion workflow for loading CSV files into a database. The changes include the addition of a configuration file to specify ingestion details and a Jupyter notebook to handle the ingestion process programmatically.

### Data ingestion configuration:

* Added a new `config/ingestion.json` file to define the mapping between database tables and their corresponding CSV file paths. This file includes entries for tables such as `clientes`, `devolucoes`, `itens_devolucao`, `itens_venda`, `produtos`, and `vendas`.

### Data ingestion notebook:

* Created a new Jupyter notebook `notebooks/ingestion.ipynb` to automate the ingestion process. Key functionalities include:
  - Loading the ingestion configuration from `ingestion.json`.
  - Reading CSV files into Pandas DataFrames and handling potential errors during file reading.
  - Parsing and formatting date columns (e.g., `data_venda`) using `pd.to_datetime`.
  - Establishing a connection to a MySQL database using SQLAlchemy and loading data into the database with `to_sql`.