### PR TITLE
feat(sql): add calculation for total returned value and net sales excluding returns and cancellations

### DIFF
--- a/sql/customer_behavior.sql
+++ b/sql/customer_behavior.sql
@@ -6,7 +6,7 @@ WITH valor_itens_devolvidos_aprovados_por_venda AS (
 	FROM devolucoes d
 	JOIN itens_devolucao idv ON d.id_devolucao = idv.id_devolucao
 	JOIN itens_venda iv ON idv.id_item_venda = iv.id_item_venda
-	WHERE d.status_devolucao IN ("aprovada", "finalizada")
+	WHERE d.status_devolucao IN ('aprovada', 'finalizada')
 	GROUP BY d.id_venda
 ),
 

--- a/sql/customer_behavior.sql
+++ b/sql/customer_behavior.sql
@@ -1,25 +1,31 @@
--- TOP 10 CLIENTES POR VALOR TOTAL GASTO E POR NÚMERO DE COMPRAS
+-- Valor total devolvido efetivamente por vendas
+WITH valor_itens_devolvidos_aprovados_por_venda AS (
+	SELECT
+		d.id_venda,
+		SUM(iv.preco_unitario) AS total_valor_devolvido_aprovado
+	FROM devolucoes d
+	JOIN itens_devolucao idv ON d.id_devolucao = idv.id_devolucao
+	JOIN itens_venda iv ON idv.id_item_venda = iv.id_item_venda
+	WHERE d.status_devolucao IN ("aprovada", "finalizada")
+	GROUP BY d.id_venda
+),
 
--- Top 10 total compras
-SELECT id_cliente,
-        nome_cliente,
-        SUM(numero_compras) AS total_compras_cliente
-FROM clientes
-GROUP BY id_cliente
-ORDER BY total_compras_cliente DESC
-LIMIT 10;
+-- Valor líquido das vendas (exclusão das devoluções e vendas canceladas)
+valor_liquido_vendas AS (
+        SELECT
+                v.id_venda,
+                v.id_cliente,
+                v.data_venda,
+                v.canal_venda,
+                v.status_venda,
+                v.total_venda AS total_venda_bruta,
+                COALESCE(vida.total_valor_devolvido_aprovado, 0) AS total_devolvido_venda,
+                CASE
+                        WHEN v.status_venda = "cancelada" THEN 0 -- Vendas canceladas não entrarão em valores líquidos
+                        ELSE(v.total_venda - COALESCE(vida.total_valor_devolvido_aprovado, 0))
+                END AS total_venda_liquida
+        FROM vendas v
+        LEFT JOIN valor_itens_devolvidos_aprovados_por_venda vida ON v.id_venda = vida.id_venda
+)
 
--- Top 10 valor gasto
-SELECT id_cliente,
-        nome_cliente,
-        total_gasto
-FROM clientes
-ORDER BY total_gasto DESC
-LIMIT 10;
-
--- VALOR MÉDIO DE COMPRAS POR CLIENTE (AOV) E TICKET MÉDIO
-
--- Valor médio de compras (apenas compras com status "concluída")
-SELECT AVG(total_venda) AS aov_cliente
-FROM vendas
-WHERE status_venda = 'concluída';
+SELECT * FROM valor_liquido_vendas;


### PR DESCRIPTION
This pull request introduces significant changes to the `sql/customer_behavior.sql` file, focusing on enhancing the analysis of customer behavior by incorporating more nuanced calculations for sales data, including handling refunds and cancellations. The previous queries for top customers and average order values have been replaced with a more detailed approach to calculate net sales values and refunds.

### Enhancements to sales data calculations:
* Added a new Common Table Expression (CTE) `valor_itens_devolvidos_aprovados_por_venda` to calculate the total value of approved refunds per sale. This ensures refunds are accounted for in the analysis.
* Introduced the `valor_liquido_vendas` CTE to compute the net sales value for each transaction by subtracting refunds and excluding canceled sales. This provides a more accurate representation of sales performance.

### Removal of outdated queries:
* Removed the queries for top 10 customers by total purchases and total spending, simplifying the focus to net sales calculations.
* Eliminated the query for calculating the average order value (AOV) for completed purchases, replacing it with a broader net sales analysis approach.