### PR TITLE
feat(sql): add queries for top clients by spending and purchase count

### DIFF
--- a/sql/customer_behavior.sql
+++ b/sql/customer_behavior.sql
@@ -21,11 +21,32 @@ valor_liquido_vendas AS (
                 v.total_venda AS total_venda_bruta,
                 COALESCE(vida.total_valor_devolvido_aprovado, 0) AS total_devolvido_venda,
                 CASE
-                        WHEN v.status_venda = "cancelada" THEN 0 -- Vendas canceladas não entrarão em valores líquidos
+                        WHEN v.status_venda = 'cancelada' THEN 0 -- Vendas canceladas não entrarão em valores líquidos
                         ELSE(v.total_venda - COALESCE(vida.total_valor_devolvido_aprovado, 0))
                 END AS total_venda_liquida
         FROM vendas v
         LEFT JOIN valor_itens_devolvidos_aprovados_por_venda vida ON v.id_venda = vida.id_venda
 )
 
-SELECT * FROM valor_liquido_vendas;
+-- Top 10 clientes por valor gasto
+SELECT 
+        vlv.id_cliente,
+        c.nome_cliente,
+        SUM(vlv.total_venda_liquida) AS total_liquido_gasto_cliente
+FROM valor_liquido_vendas vlv
+JOIN clientes c ON vlv.id_cliente = c.id_cliente
+GROUP BY vlv.id_cliente, c.nome_cliente
+ORDER BY total_liquido_gasto_cliente DESC
+LIMIT 10;
+
+-- Top 10 clientes por compras efetivadas
+SELECT
+        v.id_cliente,
+        c.nome_cliente,
+        COUNT(DISTINCT id_venda) AS num_compras_validas_cliente
+FROM vendas v
+JOIN clientes c ON v.id_cliente = c.id_cliente
+WHERE status_venda IN ('concluida', 'devolvida parcialmente')
+GROUP BY id_cliente
+ORDER BY num_compras_validas_cliente DESC
+LIMIT 10;

--- a/sql/customer_behavior.sql
+++ b/sql/customer_behavior.sql
@@ -43,7 +43,7 @@ LIMIT 10;
 SELECT
         v.id_cliente,
         c.nome_cliente,
-        COUNT(DISTINCT id_venda) AS num_compras_validas_cliente
+        COUNT(DISTINCT v.id_venda) AS num_compras_validas_cliente
 FROM vendas v
 JOIN clientes c ON v.id_cliente = c.id_cliente
 WHERE status_venda IN ('concluida', 'devolvida parcialmente')

--- a/sql/customer_behavior.sql
+++ b/sql/customer_behavior.sql
@@ -47,6 +47,6 @@ SELECT
 FROM vendas v
 JOIN clientes c ON v.id_cliente = c.id_cliente
 WHERE status_venda IN ('concluida', 'devolvida parcialmente')
-GROUP BY id_cliente
+GROUP BY id_cliente, c.nome_cliente
 ORDER BY num_compras_validas_cliente DESC
 LIMIT 10;

--- a/sql/customer_behavior.sql
+++ b/sql/customer_behavior.sql
@@ -46,7 +46,7 @@ SELECT
         COUNT(DISTINCT v.id_venda) AS num_compras_validas_cliente
 FROM vendas v
 JOIN clientes c ON v.id_cliente = c.id_cliente
-WHERE status_venda IN ('concluida', 'devolvida parcialmente')
+WHERE v.status_venda IN ('concluida', 'devolvida parcialmente')
 GROUP BY id_cliente, c.nome_cliente
 ORDER BY num_compras_validas_cliente DESC
 LIMIT 10;


### PR DESCRIPTION
This pull request introduces changes to the SQL query logic in `sql/customer_behavior.sql` to improve data insights and correct syntax issues. The main updates include fixing a string syntax error and adding two new queries to analyze customer behavior.

### Fixes and Improvements:

* Corrected the string syntax for the `status_venda` condition in the `CASE` statement from double quotes (`"cancelada"`) to single quotes (`'cancelada'`) to align with SQL standards.

### New Queries for Customer Insights:

* Added a query to retrieve the top 10 customers by total net spending (`total_liquido_gasto_cliente`), grouped by customer ID and name, and ordered in descending order of spending.
* Added a query to retrieve the top 10 customers by the number of valid purchases (`num_compras_validas_cliente`), considering only completed or partially returned sales, grouped by customer ID and name, and ordered in descending order of purchase count.