### PR TITLE
Analysis with sql

### DIFF
--- a/sql/customer_behavior.sql
+++ b/sql/customer_behavior.sql
@@ -1,43 +1,21 @@
--- Valor total devolvido efetivamente por vendas
-WITH valor_itens_devolvidos_aprovados_por_venda AS (
-	SELECT
-		d.id_venda,
-		SUM(iv.preco_unitario) AS total_valor_devolvido_aprovado
-	FROM devolucoes d
-	JOIN itens_devolucao idv ON d.id_devolucao = idv.id_devolucao
-	JOIN itens_venda iv ON idv.id_item_venda = iv.id_item_venda
-	WHERE d.status_devolucao IN ('aprovada', 'finalizada')
-	GROUP BY d.id_venda
-),
-
--- Valor líquido das vendas (exclusão das devoluções e vendas canceladas)
-valor_liquido_vendas AS (
-        SELECT
-                v.id_venda,
-                v.id_cliente,
-                v.data_venda,
-                v.canal_venda,
-                v.status_venda,
-                v.total_venda AS total_venda_bruta,
-                COALESCE(vida.total_valor_devolvido_aprovado, 0) AS total_devolvido_venda,
-                CASE
-                        WHEN v.status_venda = 'cancelada' THEN 0 -- Vendas canceladas não entrarão em valores líquidos
-                        ELSE(v.total_venda - COALESCE(vida.total_valor_devolvido_aprovado, 0))
-                END AS total_venda_liquida
-        FROM vendas v
-        LEFT JOIN valor_itens_devolvidos_aprovados_por_venda vida ON v.id_venda = vida.id_venda
-)
-
 -- Top 10 clientes por valor gasto
 SELECT 
         vlv.id_cliente,
         c.nome_cliente,
         SUM(vlv.total_venda_liquida) AS total_liquido_gasto_cliente
-FROM valor_liquido_vendas vlv
+FROM vw_valor_liquido_vendas vlv
 JOIN clientes c ON vlv.id_cliente = c.id_cliente
 GROUP BY vlv.id_cliente, c.nome_cliente
 ORDER BY total_liquido_gasto_cliente DESC
 LIMIT 10;
+
+-- Valor médio de compra por cliente (AOV)
+SELECT
+        vlv.id_cliente,
+        AVG(vlv.total_venda_liquida) AS aov_liquido_cliente
+FROM vw_valor_liquido_vendas vlv
+WHERE vlv.status_venda IN ('concluida', 'devolvida parcialmente')
+GROUP BY vlv.id_cliente;
 
 -- Top 10 clientes por compras efetivadas
 SELECT
@@ -50,3 +28,4 @@ WHERE v.status_venda IN ('concluida', 'devolvida parcialmente')
 GROUP BY id_cliente, c.nome_cliente
 ORDER BY num_compras_validas_cliente DESC
 LIMIT 10;
+

--- a/sql/views_customer_behavior.sql
+++ b/sql/views_customer_behavior.sql
@@ -1,0 +1,40 @@
+-- Valor total devolvido efetivamente por vendas
+CREATE VIEW vw_valor_itens_devolvidos_aprovados_por_venda AS 
+SELECT
+		d.id_venda,
+		SUM(iv.preco_unitario) AS total_valor_devolvido_aprovado
+FROM devolucoes d
+JOIN itens_devolucao idv ON d.id_devolucao = idv.id_devolucao
+JOIN itens_venda iv ON idv.id_item_venda = iv.id_item_venda
+WHERE d.status_devolucao IN ('aprovada', 'finalizada')
+GROUP BY d.id_venda;
+
+-- Valor líquido das vendas (exclusão das devoluções e vendas canceladas)
+CREATE VIEW vw_valor_liquido_vendas AS
+    SELECT 
+        v.id_venda,
+        v.id_cliente,
+        v.data_venda,
+        v.canal_venda,
+        v.status_venda,
+        v.total_venda AS total_venda_bruta,
+        COALESCE(vida.total_valor_devolvido_aprovado, 0) AS total_devolvido_venda,
+        CASE
+            WHEN v.status_venda = 'cancelada' THEN 0
+            ELSE (v.total_venda - COALESCE(vida.total_valor_devolvido_aprovado, 0))
+        END AS total_venda_liquida
+    FROM
+        vendas v
+            LEFT JOIN
+        vw_valor_itens_devolvidos_aprovados_por_venda vida ON v.id_venda = vida.id_venda;
+
+-- Itens efetivamente devolvidos
+CREATE VIEW vw_itens_devolvidos AS
+    SELECT DISTINCT
+        idv.id_item_venda
+    FROM
+        devolucoes d
+            JOIN
+        itens_devolucao idv ON d.id_devolucao = idv.id_devolucao
+    WHERE
+        d.status_devolucao IN ('aprovada' , 'finalizada');


### PR DESCRIPTION
This pull request refactors SQL queries for customer behavior analysis by introducing new views to simplify and modularize the code. The most significant changes include replacing inline subqueries with reusable views, adding a new query for average order value (AOV) per customer, and improving query maintainability.

### Refactoring with Views:

* Created `vw_valor_itens_devolvidos_aprovados_por_venda` to encapsulate logic for calculating the total value of approved returns per sale. This replaces the inline subquery in the original query. (`sql/views_customer_behavior.sql`, [sql/views_customer_behavior.sqlR1-R40](diffhunk://#diff-23aa94d37f438b9694f52cd5117defac7203c87da2257567007260017624ac11R1-R40))
* Created `vw_valor_liquido_vendas` to calculate net sales values, factoring in cancellations and approved returns. This view replaces the previously defined `valor_liquido_vendas` CTE. (`sql/views_customer_behavior.sql`, [sql/views_customer_behavior.sqlR1-R40](diffhunk://#diff-23aa94d37f438b9694f52cd5117defac7203c87da2257567007260017624ac11R1-R40))
* Created `vw_itens_devolvidos` to identify distinct items that were effectively returned, improving modularity. (`sql/views_customer_behavior.sql`, [sql/views_customer_behavior.sqlR1-R40](diffhunk://#diff-23aa94d37f438b9694f52cd5117defac7203c87da2257567007260017624ac11R1-R40))

### Query Enhancements:

* Added a new query to calculate the average order value (AOV) per customer based on net sales. This provides additional insights into customer spending behavior. (`sql/customer_behavior.sql`, [sql/customer_behavior.sqlL1-R19](diffhunk://#diff-4b5dbdab7bb6cf01698afa021a2a6934d0255d8915255cfbe0bd83dd3a7a299aL1-R19))

### Code Simplification:

* Updated existing queries to use the new `vw_valor_liquido_vendas` view instead of inline logic, reducing redundancy and improving readability. (`sql/customer_behavior.sql`, [[1]](diffhunk://#diff-4b5dbdab7bb6cf01698afa021a2a6934d0255d8915255cfbe0bd83dd3a7a299aL1-R19) [[2]](diffhunk://#diff-4b5dbdab7bb6cf01698afa021a2a6934d0255d8915255cfbe0bd83dd3a7a299aR31)