### PR TITLE
feat(sql): add sales performance query by sales channel

### DIFF
--- a/sql/sales_performance.sql
+++ b/sql/sales_performance.sql
@@ -33,4 +33,18 @@ FROM
 GROUP BY p.id_produto , p.nome_produto , p.categoria
 ORDER BY receita_liquida_produtos DESC;
 
--- 
+-- Desempenho de venda por canal de venda
+SELECT
+    canal_venda,
+    SUM(total_venda_liquida) AS receita_liquida_canal,
+    COUNT(DISTINCT CASE
+            WHEN status_venda IN ('concluída' , 'devolvida parcialmente') THEN id_venda
+            ELSE NULL
+        END) AS num_vendas_canal,
+    AVG(CASE
+        WHEN status_venda IN ('concluída' , 'devolvida parcialmente') THEN total_venda_liquida
+        ELSE NULL
+    END) AS ticket_medio_canal
+FROM
+    vw_valor_liquido_vendas
+GROUP BY canal_venda;


### PR DESCRIPTION
This pull request adds a new query to the `sql/sales_performance.sql` file to analyze sales performance by sales channel. The query calculates key metrics such as total revenue, number of sales, and average ticket value for each channel.

Changes related to sales performance analysis:

* [`sql/sales_performance.sql`](diffhunk://#diff-ee98b3af450380726ad21bc12268b57f147f7fbaca98c93bce50cc68427198d2L36-R50): Added a new query to compute sales performance metrics (`receita_liquida_canal`, `num_vendas_canal`, `ticket_medio_canal`) grouped by `canal_venda`. The metrics include total revenue, count of distinct sales with specific statuses, and average ticket value for completed or partially returned sales.