### PR TITLE
feat(sql): add returns analysis query to calculate product return rates

### DIFF
--- a/sql/returns_analysis.sql
+++ b/sql/returns_analysis.sql
@@ -1,0 +1,35 @@
+WITH performance_produtos AS (
+    SELECT 
+    p.id_produto,
+    p.nome_produto,
+    p.categoria,
+    COUNT(vid.id_item_venda) AS unidades_devolvidas_aprovadas,
+    COUNT(CASE
+        WHEN vid.id_item_venda IS NULL THEN iv.id_item_venda
+    END) AS unidades_vendidas_liquidas
+FROM
+    itens_venda iv
+        JOIN
+    produtos p ON iv.id_produto = p.id_produto
+        JOIN
+    vendas v ON iv.id_venda = v.id_venda
+        LEFT JOIN
+    vw_itens_devolvidos vid ON iv.id_item_venda = vid.id_item_venda
+WHERE
+    v.status_venda IN ('concluída' , 'devolvida parcialmente')
+GROUP BY p.id_produto , p.nome_produto , p.categoria
+)
+
+-- Taxa de devolução dos produtos
+SELECT 
+    nome_produto,
+    categoria,
+    unidades_devolvidas_aprovadas,
+    unidades_vendidas_liquidas,
+    CASE
+        WHEN (unidades_devolvidas_aprovadas + unidades_vendidas_liquidas) = 0 THEN 0
+        ELSE (unidades_devolvidas_aprovadas * 1.0 / (unidades_devolvidas_aprovadas + unidades_vendidas_liquidas)) * 100
+    END AS taxa_devolucao
+FROM
+    performance_produtos
+ORDER BY taxa_devolucao DESC;


### PR DESCRIPTION
This pull request introduces a new SQL query in the `sql/returns_analysis.sql` file to analyze product performance based on return rates. The query calculates the return rate for each product by leveraging data from sales, products, and returned items.

Key additions:

### Return rate analysis:

* Added a `WITH` clause (`performance_produtos`) to aggregate product data, including the number of approved returned units (`unidades_devolvidas_aprovadas`) and net sold units (`unidades_vendidas_liquidas`).
* Implemented a main query to calculate the return rate (`taxa_devolucao`) for each product as a percentage, with handling for cases where no sales or returns exist. The results are ordered by return rate in descending order.